### PR TITLE
Function now returns a `Result<f64, CustomError>` 

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -1,7 +1,35 @@
+use std::fmt;
+/// Custom error that can occur with the Function class defined below.
+#[derive(Debug, PartialEq)]
+pub enum FunctionError {
+    /// The Function could not compute the function value because the
+    /// Vector provided does not have the right number of arguments.
+    WrongNumberOfEntries {
+        /// Expected number of arguments.
+        expected_number_of_entries: usize,
+        /// Actual number of arguments.
+        actual_number_of_entries: usize,
+    },
+}
+impl fmt::Display for FunctionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FunctionError::WrongNumberOfEntries {
+                expected_number_of_entries,
+                actual_number_of_entries,
+            } => write!(
+                f,
+                "Expected {} entries, but got {}",
+                expected_number_of_entries, actual_number_of_entries
+            ),
+        }
+    }
+}
+
 /// A representation of a f64 based distance matrix.
 #[derive(Debug)]
 pub struct Function {
-    fun: fn((f64, f64, f64)) -> f64,
+    fun: fn(Vec<f64>) -> Result<f64, FunctionError>,
 }
 
 impl Function {
@@ -16,10 +44,18 @@ impl Function {
     /// ```
     /// use genetic_algorithm_fn::function;
     ///
-    /// let my_func = function::Function::new(|(x, y, z)| {x * y * z});
+    /// let function_to_optimize = function::Function::new(
+    ///     |x| match x.len() {
+    ///         3 => Ok(x[0] * x[1] * x[2]),
+    ///         _ => Err(function::FunctionError::WrongNumberOfEntries {
+    ///             actual_number_of_entries: x.len(),
+    ///             expected_number_of_entries: 3,
+    ///         }),
+    ///     }
+    /// );
     ///
     /// ```
-    pub fn new(fun: fn((f64, f64, f64)) -> f64) -> Self {
+    pub fn new(fun: fn(Vec<f64>) -> Result<f64, FunctionError>) -> Self {
         Function { fun }
     }
     /// Compute the function value for a Solution.
@@ -33,11 +69,19 @@ impl Function {
     /// ```
     /// use genetic_algorithm_fn::function;
     ///
-    /// let my_func = function::Function::new(|(x, y, z)| {x * y * z});
-    /// println!("{}", my_func.get_function_value((3.0, 4.0, 5.0)));
+    /// let function_to_optimize = function::Function::new(
+    ///     |x| match x.len() {
+    ///         3 => Ok(x[0] * x[1] * x[2]),
+    ///         _ => Err(function::FunctionError::WrongNumberOfEntries {
+    ///             actual_number_of_entries: x.len(),
+    ///             expected_number_of_entries: 3,
+    ///         }),
+    ///     }
+    /// );
+    /// println!("{}", function_to_optimize.get_function_value(vec![3.0, 4.0, 5.0]).unwrap());
     ///
     /// ```
-    pub fn get_function_value(&self, function_values: (f64, f64, f64)) -> f64 {
+    pub fn get_function_value(&self, function_values: Vec<f64>) -> Result<f64, FunctionError> {
         (self.fun)(function_values)
     }
 }
@@ -45,13 +89,32 @@ impl Function {
 #[cfg(test)]
 mod test_distance_mat {
     use super::*;
+    use crate::test_objects;
     #[test]
     fn test_constructor() {
-        let _ = Function::new(|(x, y, z)| x * y * z);
+        let _ = Function::new(|x| match x.len() {
+            3 => Ok(x[0] * x[1] * x[2]),
+            _ => Err(FunctionError::WrongNumberOfEntries {
+                actual_number_of_entries: x.len(),
+                expected_number_of_entries: 3,
+            }),
+        });
     }
     #[test]
     fn test_simple_computation() {
-        let my_func = Function::new(|(x, y, z)| x * y * z);
-        assert_eq!(my_func.get_function_value((1.0, 2.0, 3.0)), 6.0);
+        let my_func = Function::new(test_objects::triple_multiplication());
+
+        assert_eq!(my_func.get_function_value(vec![1.0, 2.0, 3.0]), Ok(6.0));
+    }
+    #[test]
+    fn test_simple_computation_wrong_arguments() {
+        let my_func = Function::new(test_objects::triple_multiplication());
+        assert_eq!(
+            my_func.get_function_value(vec![1.0, 2.0]),
+            Err(FunctionError::WrongNumberOfEntries {
+                expected_number_of_entries: 3,
+                actual_number_of_entries: 2
+            })
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,7 @@ pub mod solution;
 pub mod solutions;
 /// Testing functions to optimize.
 pub mod test_functions;
+/// functions to create default objects for testing.
+/// Both for convenience (not having to create them over and over again)
+/// as well as standardization (test against the same common cases).
+mod test_objects;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,26 @@ use genetic_algorithm_fn::test_functions;
 
 fn main() {
     let initial_params_range = -150.0..150.0;
-    let function_to_optimize =
-        function::Function::new(|(x, y, z)| -test_functions::hartman_3_dimensional(x, y, z));
+    let function_to_optimize = function::Function::new(|x| {
+        Ok(-test_functions::hartman_3_dimensional(
+            *x.get(0)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+            *x.get(1)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+            *x.get(2)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+        ))
+    });
+
     // Single-threaded test
     for n_generations in (10..=510).step_by(250) {
         for size_generation in (10..=40).step_by(10) {

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -247,13 +247,27 @@ impl<'a> Individual<'a> for Solution {
     /// use genetic_algorithm_fn::function;
     /// use genetic_algorithm_traits::Individual;
     ///
-    /// let my_function = function::Function::new(|(x, y, z)| { x * y * z });
+    /// let function_to_optimize = function::Function::new(
+    ///     |x| match x.len() {
+    ///         3 => Ok(x[0] * x[1] * x[2]),
+    ///         _ => Err(function::FunctionError::WrongNumberOfEntries {
+    ///             actual_number_of_entries: x.len(),
+    ///             expected_number_of_entries: 3,
+    ///         }),
+    ///     }
+    /// );
     /// let this_solution = solution::Solution::new(2.0, 3.0, 5.0);
-    /// println!("{}", this_solution.fitness(&my_function));
+    /// println!("{}", this_solution.fitness(&function_to_optimize));
     /// ```
     ///
     fn fitness(&self, function: &function::Function) -> f64 {
-        function.get_function_value(self.get_arguments())
+        function
+            .get_function_value(vec![
+                self.get_arguments().0,
+                self.get_arguments().1,
+                self.get_arguments().2,
+            ])
+            .unwrap()
     }
 }
 
@@ -287,7 +301,7 @@ mod tests {
 
     mod test_solution {
         use super::*;
-
+        use crate::test_objects;
         #[test]
         fn test_constructor() {
             // Ensure the constructor is working.
@@ -303,8 +317,9 @@ mod tests {
         #[test]
         fn fitness() {
             assert_eq!(
-                Solution::new(2.0, 3.0, 5.0)
-                    .fitness(&function::Function::new(|(x, y, z)| { x * y * z })),
+                Solution::new(2.0, 3.0, 5.0).fitness(&function::Function::new(
+                    test_objects::triple_multiplication()
+                )),
                 30.0
             )
         }
@@ -444,7 +459,8 @@ mod tests {
             use super::*;
             #[test]
             fn simple_test() {
-                let function_to_maximize = function::Function::new(|(x, y, z)| x * y * z);
+                let function_to_maximize =
+                    function::Function::new(test_objects::triple_multiplication());
                 let solution = Solution::new(1.0, 4.0, 7.0);
                 assert_eq!(solution.fitness(&function_to_maximize), 28.0);
             }

--- a/src/solutions.rs
+++ b/src/solutions.rs
@@ -105,7 +105,15 @@ impl<'a> Population<'a> for Solutions {
     /// use genetic_algorithm_fn::function;
     /// use genetic_algorithm_traits::Population;
     ///
-    /// let function_to_optimize = function::Function::new(|(x,y,z)| {x*y*z});
+    /// let function_to_optimize = function::Function::new(
+    ///     |x| match x.len() {
+    ///         3 => Ok(x[0] * x[1] * x[2]),
+    ///         _ => Err(function::FunctionError::WrongNumberOfEntries {
+    ///             actual_number_of_entries: x.len(),
+    ///             expected_number_of_entries: 3,
+    ///         }),
+    ///     }
+    /// );
     /// let all_solutions = solutions::Solutions::random(30, 1.0..10.0);
     /// println!("Best 5 solutions: {}", all_solutions.get_fittest_population(5, &function_to_optimize));
     /// ```

--- a/src/test_objects.rs
+++ b/src/test_objects.rs
@@ -1,0 +1,10 @@
+use crate::function;
+pub fn triple_multiplication() -> fn(Vec<f64>) -> Result<f64, function::FunctionError> {
+    |x| match x.len() {
+        3 => Ok(x[0] * x[1] * x[2]),
+        _ => Err(function::FunctionError::WrongNumberOfEntries {
+            actual_number_of_entries: x.len(),
+            expected_number_of_entries: 3,
+        }),
+    }
+}

--- a/tests/test_genetic.rs
+++ b/tests/test_genetic.rs
@@ -7,8 +7,25 @@ use genetic_algorithm_traits::Population;
 #[test]
 fn test_end_to_end() {
     // Use the hartman function to test whether a realistic function can be maximized.
-    let function_to_optimize =
-        function::Function::new(|(x, y, z)| -test_functions::hartman_3_dimensional(x, y, z));
+    let function_to_optimize = function::Function::new(|x| {
+        Ok(-test_functions::hartman_3_dimensional(
+            *x.get(0)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+            *x.get(1)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+            *x.get(2)
+                .ok_or(function::FunctionError::WrongNumberOfEntries {
+                    expected_number_of_entries: 3,
+                    actual_number_of_entries: x.len(),
+                })?,
+        ))
+    });
 
     // End-to-end test: does the error of the solution get down?
     let solutions = solutions::Solutions::random(50, -10.0..10.0);


### PR DESCRIPTION
In order to move from a Solution having a fixed number of entries (eg. function values) to be dynamic and accept multiple function values, we first need to rewrite `Function` to return an `Err<f64, CustomError` because we need to account for the possibility of mis-matched `Function` and `Solution`. This can happen when the function in `Function` requires n function arguments but `Solution` does only store m and m != n.